### PR TITLE
move fast-glob to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,14 +12,14 @@
   ],
   "author": "MQuy",
   "license": "MIT",
-  "devDependencies": {
-    "chalk": "^2.0.0",
+  "peerDependencies": {
     "webpack": "> 3"
   },
   "engines": {
     "node": ">=6.11.5"
   },
   "dependencies": {
+    "chalk": "^2.0.0",
     "fast-glob": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,10 +14,12 @@
   "license": "MIT",
   "devDependencies": {
     "chalk": "^2.0.0",
-    "fast-glob": "^2.0.0",
     "webpack": "> 3"
   },
   "engines": {
     "node": ">=6.11.5"
+  },
+  "dependencies": {
+    "fast-glob": "^2.0.0"
   }
 }


### PR DESCRIPTION
There was `Error: Cannot find module 'fast-glob'` when using this plugin, so move the package `fast-glob` to `dependencies`.

It can be reproduced in the samples directory:
- Don't `yarn install` in `webpack-deadcode-plugin` directory.
- `cd samples && yarn`.
- `yarn build` in samples directory.

Then error occurred as below:
 
![screen shot 2019-01-24 at 10 10 17 pm](https://user-images.githubusercontent.com/23313266/51683473-eab2ab00-2024-11e9-8e54-d5355a48429c.png)
