### PR TITLE
Fix TypeError when module.usedExports is null

### DIFF
--- a/src/detect.js
+++ b/src/detect.js
@@ -50,7 +50,9 @@ function getUsedExportMap(includedFileMap, compilation) {
         if (module.usedExports === false) {
           unusedExportMap[path] = providedExports;
         } else if (providedExports instanceof Array) {
-          const unusedExports = providedExports.filter(x => !module.usedExports.includes(x));
+          const unusedExports = providedExports.filter(
+            x => module.usedExports instanceof Array && !module.usedExports.includes(x)
+          );
 
           if (unusedExports.length > 0) {
             unusedExportMap[path] = unusedExports;


### PR DESCRIPTION
Behavior hasn't been modified (i-e as to why module.usedExports is null).