### PR TITLE
fix: undefined paths

### DIFF
--- a/src/detect.js
+++ b/src/detect.js
@@ -95,7 +95,7 @@ function getWebpackAssets(compilation) {
 
 function convertFilesToDict(assets) {
   return assets
-    .filter(file => file.indexOf("node_modules") === -1)
+    .filter(file => file && file.indexOf("node_modules") === -1)
     .reduce((acc, file) => {
       const unixFile = convertToUnixPath(file);
 


### PR DESCRIPTION
Plugin | version
--|--
Plugin version | 0.1.11
Webpack version | 4.29.6


Using the plugin throw an error cause it tries to parse unexistant files.

It seems sometimes, in `getWebpackAssets` the `existsAt` is `undefined` but in `convertFilesToDict` it uses the path as if it's sure it exists. This PR fixes this.