### PR TITLE
Use context for exclude patterns

### DIFF
--- a/src/detect.js
+++ b/src/detect.js
@@ -37,7 +37,7 @@ function detectDeadCode(compilation, options) {
 function getPattern({ context, patterns, exclude }) {
 	return patterns
 		.map(pattern => path.resolve(context, pattern))
-		.concat(exclude.map(pattern => `!${pattern}`))
+		.concat(exclude.map(pattern => `!${path.resolve(context, pattern)}`))
 		.map(convertToUnixPath);
 }
 


### PR DESCRIPTION
Fixes #44. I've tested this locally on an app with multiple bundles on webpack 5. It seems to work. 

A workaround for this is to just use recursive ignores `**/__mocks__/**` or something