### PR TITLE
feat: support export result to json and support not showing logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,14 @@ Whether to run unused export detection or not.
 #### options.log (default: `"all"`)
 
 `"all"`: show all messages.
+
 `"unused"`: only show messages when there are either unused files or unused export.
+
+`"none"`: won't show unused files or unused export messages in the terminal, it can keep terminal clean when set `exportJSON` to `true`
+
+#### options.exportJSON (default: `false`)
+
+When set to `true`, it will export the unused files and unused export to a JSON file called `deadcode.json` at the root of the project.
 
 [npm]: https://img.shields.io/npm/v/webpack-deadcode-plugin.svg
 [npm-url]: https://npmjs.com/package/webpack-deadcode-plugin

--- a/README.md
+++ b/README.md
@@ -145,7 +145,20 @@ Whether to run unused export detection or not.
 
 #### options.exportJSON (default: `false`)
 
-When set to `true`, it will export the unused files and unused export to a JSON file called `deadcode.json` at the root of the project.
+`false`: won't create `deadcode.json` for the unused files and unused export.
+
+`true`: create `deadcode.json` for the unused files and unused export at the root of the project.
+
+You can set `exportJSON` to a specific path, and it will generate `deadcode.json` in that path.
+
+```js
+new DeadCodePlugin({
+  patterns: ["*.(js|css)"],
+  exclude: ["**/node_modules/**"],
+  log: "none",
+  exportJSON: "./analysis"
+}),
+```
 
 [npm]: https://img.shields.io/npm/v/webpack-deadcode-plugin.svg
 [npm-url]: https://npmjs.com/package/webpack-deadcode-plugin

--- a/samples/webpack.config.js
+++ b/samples/webpack.config.js
@@ -1,5 +1,5 @@
 const webpack = require("webpack");
-const DeadCodePlugin = require("webpack-deadcode-plugin");
+const DeadCodePlugin = require("../src/index");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 
 module.exports = {

--- a/samples/yarn.lock
+++ b/samples/yarn.lock
@@ -921,9 +921,9 @@ camelcase@^5.0.0:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-lite@^1.0.30001254:
-  version "1.0.30001257"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001257.tgz#150aaf649a48bee531104cfeda57f92ce587f6e5"
-  integrity sha512-JN49KplOgHSXpIsVSF+LUyhD8PUp6xPpAXeRrrcBh4KBeP7W864jHn6RvzJgDlrReyeVjMFJL3PLpPvKIxlIHA==
+  version "1.0.30001356"
+  resolved "https://registry.npmmirror.com/caniuse-lite/-/caniuse-lite-1.0.30001356.tgz"
+  integrity sha512-/30854bktMLhxtjieIxsrJBfs2gTM1pel6MXKF3K+RdIVJZcsn2A2QdhsuR4/p9+R204fZw0zCBBhktX8xWuyQ==
 
 chalk@^2.0.0:
   version "2.4.2"
@@ -4057,7 +4057,7 @@ webpack-cli@4.8.0:
     webpack-merge "^5.7.3"
 
 webpack-deadcode-plugin@../:
-  version "0.1.15"
+  version "0.1.16"
   dependencies:
     chalk "^3.0.0"
     fast-glob "^3.1.1"

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ class WebpackDeadcodePlugin {
 				detectUnusedFiles: true,
 				detectUnusedExport: true,
 				log: "all",
+				exportJSON: false,
 			},
 			this.options,
 		);


### PR DESCRIPTION
@MQuy hi, here is the change for the export result to json files, please help to review this. thx.

There are two main things inside:
1. Add a new option called `exportJSON`, support boolean and path.
2. Allow set log to `none` for not showing message.

Beside, I found that the `samples/webpack.config.js` can not load the local package, so I change the path to '../src/index'

Close https://github.com/MQuy/webpack-deadcode-plugin/issues/56
